### PR TITLE
Document how to minimize

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ require("html?attrs=img:src img:data-src!./file.html");
 require("html?attrs[]=img:src&attrs[]=img:data-src!./file.html");
 // => '<img  src="http://cdn.example.com/49e...ba9f/a9f...92ca.jpg"  data-src="data:image/png;base64,..." >'
 
-/// minimized
+/// minimized by running `webpack --optimize-minimize`
 // => '<img src=http://cdn.example.com/49e...ba9f/a9f...92ca.jpg data-src=data:image/png;base64,...>'
 ```
 


### PR DESCRIPTION
After looking at the loader README, the webpack documentation and the loader source code and tests, I still couldn't figure out how to have the required content minimized.

I have a file like this:

```
<!-- Example list item template. -->
<li>
  <a href="#exampleDetails?id={id}">
    <h3>#{field1} {field2}</h3>
    <p>{field3}</p>
    <span class="ui-li-count">{field4}</span>
    <p class="ui-li-aside"><strong>{field5}</strong></p>
  </a>
</li>
```

And I require it like this:

```
var x = require('html!templates/myfile.html');
```

After running webpack:

```
$ webpack --optimize-minimize
```

The bundled JavaScript code itself is minimized, but the required HTML contents is not. It looks like this:

```
e.exports='<!-- Example list item template. -->\n<li>\n  <a href="#exampleDetails?id={id}">\n    <h3>#{field1} {field2}</h3>\n    <p>{field3}</p>\n    <span class="ui-li-count">{field4}</span>\n    <p class="ui-li-aside"><strong>{field5}</strong></p>\n  </a>\n</li>\n'
```

I'm probably using it wrong, but it would really be nice to have a more detailed documentation on how to use this loader and get the HTML contents minimized.
