### PR TITLE
Fix minify options to configurable.

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@
 */
 var htmlMinifier = require("html-minifier");
 var attrParse = require("./lib/attributesParser");
+var minifyOptionParser = require('./lib/minifyOptionParser');
 var SourceNode = require("source-map").SourceNode;
 var loaderUtils = require("loader-utils");
 
@@ -46,17 +47,9 @@ module.exports = function(content) {
 	});
 	content.reverse();
 	content = content.join("");
-	if(this.minimize) {
-		content = htmlMinifier.minify(content, {
-			removeComments: true,
-			collapseWhitespace: true,
-			collapseBooleanAttributes: true,
-			removeAttributeQuotes: true,
-			removeRedundantAttributes: true,
-			useShortDoctype: true,
-			removeEmptyAttributes: true,
-			removeOptionalTags: true
-		})
+  
+	if(this.minimize) {    
+		content = htmlMinifier.minify(content, minifyOptionParser(query));
 	}
 	return "module.exports = " + JSON.stringify(content).replace(/xxxHTMLLINKxxx[0-9\.]+xxx/g, function(match) {
 		if(!data[match]) return match;

--- a/lib/minifyOptionParser.js
+++ b/lib/minifyOptionParser.js
@@ -1,0 +1,36 @@
+/*
+	MIT License http://www.opensource.org/licenses/mit-license.php
+	Author Taketoshi Aono @brn
+*/
+
+
+function convertFlags(flagStr) {
+  return flagStr === 'true';
+}
+
+
+
+module.exports = function(query) {
+  var opts = {
+    removeComments: true,
+		collapseWhitespace: true,
+		collapseBooleanAttributes: true,
+		removeAttributeQuotes: true,
+		removeRedundantAttributes: true,
+		useShortDoctype: true,
+		removeEmptyAttributes: true,
+		removeOptionalTags: true
+  };
+
+  if (query.minify) {
+    var minifyOpts = query.minify.split(" ");
+    var opt;
+    for (var i = 0, len = minifyOpts.length; i < len; i++) {
+      opt = minifyOpts[i].split(':');
+      if (opt.length === 2) {
+        opts[opt[0]] = convertFlags(opt[1]);
+      }
+    }
+  }
+  return opts;
+};


### PR DESCRIPTION
In our project, we use angular.js and all template html is compiled into a javascript file.
But we test the compiled version app, we found that all input[type=text] css value is not applied,
because html-minifier remove 'type' propery from the input tag.
So I fix minify option to be configurable.

USAGE:
{ test: /.html$/, loader: 'html-loader?minify=removeRedundantAttributes:false removeComments:false'}
Add minify param to the html-loader query parameters.
The minify paramerter is space separated values and if not specified, it treated as true.
