### PR TITLE
[WIP] Automatically call responsive-loader, generate srcset from sizes

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ var loaderUtils = require("loader-utils");
 var url = require("url");
 var assign = require("object-assign");
 var compile = require("es6-templates").compile;
+var sizesExtent = require("sizes-extent");
 
 function randomIdent() {
 	return "xxxHTMLLINKxxx" + Math.random() + Math.random() + "xxx";
@@ -64,7 +65,7 @@ module.exports = function(content) {
 		do {
 			var ident = randomIdent();
 		} while(data[ident]);
-		data[ident] = link.value;
+		data[ident] = { href: link.value, sizes: link.sizes };
 		var x = content.pop();
 		content.push(x.substr(link.start + link.length));
 		content.push(ident);
@@ -92,7 +93,7 @@ module.exports = function(content) {
 			do {
 				var ident = randomIdent();
 			} while(data[ident]);
-			data[ident] = link.value.substring(11,link.length - 3)
+			data[ident] = { href: link.value.substring(11,link.length - 3) };
 			content.push(x.substr(link.start + link.length));
 			content.push(ident);
 			content.push(x.substr(0, link.start));
@@ -140,9 +141,32 @@ module.exports = function(content) {
         exportsString = "export default ";
 	}
 
+	var MAX_DPR = 2;
+
  	return exportsString + content.replace(/xxxHTMLLINKxxx[0-9\.]+xxx/g, function(match) {
 		if(!data[match]) return match;
-		return '" + require(' + JSON.stringify(loaderUtils.urlToRequest(data[match], root)) + ') + "';
+		if(data[match].href.indexOf('?sizes[]=') !== -1) {
+			var href = data[match].href;
+			var params = href.slice(href.indexOf('?'));
+			var hrefWithoutParams = href.slice(0, href.indexOf('?'));
+
+			var requireSizes = JSON.stringify(
+				'responsive-loader' + params + '!' + loaderUtils.urlToRequest(hrefWithoutParams, root)
+			);
+			return '" + require(' + requireSizes + ').src + "\\" srcset=\\"" + require(' + requireSizes + ').srcSet + "';
+		}
+		if(data[match].sizes) {
+			var extent = sizesExtent(data[match].sizes);
+
+			if(!extent) {
+				throw new Error('sizes attribute not understood: ' + data[match].sizes);
+			}
+
+			var responsive = 'responsive-loader?min=' + extent[0] + '&max=' + (extent[1] * MAX_DPR) + '!';
+			var requireMinmax = JSON.stringify(responsive + loaderUtils.urlToRequest(data[match].href, root));
+			return '" + require(' + requireMinmax + ').src + "\\" srcset=\\"" + require(' + requireMinmax + ').srcSet + "';
+		}
+		return '" + require(' + JSON.stringify(loaderUtils.urlToRequest(data[match].href, root)) + ') + "';
 	}) + ";";
 
 }

--- a/lib/attributesParser.js
+++ b/lib/attributesParser.js
@@ -5,12 +5,31 @@
 var Parser = require("fastparse");
 
 var processMatch = function(match, strUntilValue, name, value, index) {
+	if(this.currentTag === "img" && name === "sizes") {
+		this.sizes = value;
+	}
+
+	if(this.currentTag === "img" && name === "srcset") {
+		this.skip = true;
+		return;
+	}
 	if(!this.isRelevantTagAttr(this.currentTag, name)) return;
-	this.results.push({
+	this.tmpResults.push({
 		start: index + strUntilValue.length,
 		length: value.length,
 		value: value
 	});
+};
+
+var pushResult = function() {
+	this.tmpResults.forEach(function(result) {
+		if(this.sizes && !this.skip) {
+			result.sizes = this.sizes;
+		}
+
+		this.results.push(result);
+	}.bind(this));
+	return "outside";
 };
 
 var parser = new Parser({
@@ -21,12 +40,15 @@ var parser = new Parser({
 		"<\/[^>]+>": true,
 		"<([a-zA-Z\\-:]+)\\s*": function(match, tagName) {
 			this.currentTag = tagName;
+			this.tmpResults = [];
+			this.sizes = undefined;
+			this.skip = false;
 			return "inside";
 		}
 	},
 	inside: {
 		"\\s+": true, // eat up whitespace
-		">": "outside", // end of attributes
+		">": pushResult, // end of attributes
 		"(([0-9a-zA-Z\\-:]+)\\s*=\\s*\")([^\"]*)\"": processMatch,
 		"(([0-9a-zA-Z\\-:]+)\\s*=\\s*\')([^\']*)\'": processMatch,
 		"(([0-9a-zA-Z\\-:]+)\\s*=\\s*)([^\\s>]+)": processMatch

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "fastparse": "^1.1.1",
     "html-minifier": "^3.0.1",
     "loader-utils": "^1.0.2",
-    "object-assign": "^4.1.0"
+    "object-assign": "^4.1.0",
+    "sizes-extent": "^0.1.1"
   },
   "devDependencies": {
     "beautify-lint": "^1.0.4",

--- a/test/loaderTest.js
+++ b/test/loaderTest.js
@@ -183,4 +183,24 @@ describe("loader", function() {
 			'export default "<p>Hello world!</p>";'
 		);
 	});
+	it("should call responsive-loader automatically when sizes attribute specified", function() {
+		loader.call({}, 'Text <img src="image.png" sizes="100vw"><img src="~bootstrap-img" sizes="(max-width: 800px) 100vw, 50vw"> Text').should.be.eql(
+			'module.exports = "Text <img src=\\"" + require("responsive-loader?min=320&max=2560!./image.png").src + "\\" srcset=\\"" + require("responsive-loader?min=320&max=2560!./image.png").srcSet + "\\" sizes=\\"100vw\\"><img src=\\"" + require("responsive-loader?min=320&max=1600!bootstrap-img").src + "\\" srcset=\\"" + require("responsive-loader?min=320&max=1600!bootstrap-img").srcSet + "\\" sizes=\\"(max-width: 800px) 100vw, 50vw\\"> Text";'
+		);
+	});
+	it("should call responsive-loader automatically when ?sizes[] specified", function() {
+		loader.call({}, 'Text <img src="image.png?sizes[]=400&sizes[]=500&sizes[]=600" sizes="100vw"> Text').should.be.eql(
+			'module.exports = "Text <img src=\\"" + require("responsive-loader?sizes[]=400&sizes[]=500&sizes[]=600!./image.png").src + "\\" srcset=\\"" + require("responsive-loader?sizes[]=400&sizes[]=500&sizes[]=600!./image.png").srcSet + "\\" sizes=\\"100vw\\"> Text";'
+		);
+	});
+	it("shouldn't call responsive-loader if srcset is already specified", function() {
+		loader.call({}, 'Text <img src="image.png" sizes="100vw" srcset="blablabla"> Text').should.be.eql(
+			'module.exports = "Text <img src=\\"" + require("./image.png") + "\\" sizes=\\"100vw\\" srcset=\\"blablabla\\"> Text";'
+		);
+	});
+	it("should throw when it doesn't understand sizes attribute", function() {
+		should.throws(function() {
+			loader.call({}, 'Text <img src="image.png" sizes="invalid""> Text');
+		}, /sizes attribute not understood: invalid/);
+	});
 });


### PR DESCRIPTION
Regarding: https://github.com/webpack/html-loader/issues/73

- [x] Call a responsive image loader
- [x] Make a responsive image loader actually support that syntax: https://github.com/herrstucki/responsive-loader/pull/31
- [ ] x descriptors?
- [x] Manual override: `<img src="./img.jpg?sizes[]=100&sizes[]=200&sizes[]=300">`?
- [x] Make sure srcset doesn't already exist - don't break existing stuff

~~Syntax being called doesn't actually exist yet: https://github.com/herrstucki/responsive-loader/issues/26~~ it's in a PR: https://github.com/herrstucki/responsive-loader/pull/31

This is in theory a breaking change, but only if people are using `sizes` without `srcset` already (this makes no sense). Also, we should talk about whether this should be a plugin / another loader :)