### PR TITLE
fix(getOptions): deprecation warn in loaderUtils

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,9 @@ sudo: false
 language: node_js
 os:
   - linux
-  - osx
 node_js:
   - node
   - "6"
-  - "5"
   - "4"
 
 script: npm run travis

--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ function randomIdent() {
 }
 
 function getLoaderConfig(context) {
-	var query = loaderUtils.parseQuery(context.query);
+	var query = loaderUtils.getOptions(context) || {};
 	var configKey = query.config || 'htmlLoader';
 	var config = context.options && context.options.hasOwnProperty(configKey) ? context.options[configKey] : {};
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "es6-templates": "^0.2.2",
     "fastparse": "^1.1.1",
     "html-minifier": "^3.0.1",
-    "loader-utils": "^0.2.15",
+    "loader-utils": "^1.0.2",
     "object-assign": "^4.1.0"
   },
   "license": "MIT",


### PR DESCRIPTION
**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- [x] Bugfix


**What is the current behavior?** (You can also link to an open issue here)

loader-utils throws a deprecation warning

**What is the new behavior?**

updates from parseQuery to getOptions for loaderUtils

**Does this PR introduce a breaking change?**
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the following... 

* Impact:
* Migration path for existing applications: None
* Github Issue(s) this is regarding: #113


**Other information**:

Closes #113