### PR TITLE
feat: add support for empty tags in `tag:attribute` matching

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,20 @@ By default every local `<img src="image.png">` is required (`require('./image.pn
 
 You can specify which tag-attribute combination should be processed by this loader via the query parameter `attrs`. Pass an array or a space-separated list of `<tag>:<attribute>` combinations. (Default: `attrs=img:src`)
 
+If you use `<custom-elements>`, and lots of them make use of a `custom-src` attribute, you don't have to specify each combination `<tag>:<attribute>`: just specify an empty tag like `attrs=:custom-src` and it will match every element.
+
+```js
+{
+  test: /\.(html)$/,
+  use: {
+    loader: 'html-loader',
+    options: {
+      attrs: [':data-src']
+    }
+  }
+}
+```
+
 To completely disable tag-attribute processing (for instance, if you're handling image loading on the client side) you can pass in `attrs=false`.
 
 <h2 align="center">Examples</h2>

--- a/index.js
+++ b/index.js
@@ -39,7 +39,11 @@ module.exports = function(content) {
 	}
 	var root = config.root;
 	var links = attrParse(content, function(tag, attr) {
-		return attributes.indexOf(tag + ":" + attr) >= 0;
+		var item = tag + ":" + attr;
+		var res = attributes.find(function(a) {
+		  return item.indexOf(a) >= 0;
+		});
+		return !!res;
 	});
 	links.reverse();
 	var data = {};

--- a/test/loaderTest.js
+++ b/test/loaderTest.js
@@ -29,6 +29,13 @@ describe("loader", function() {
 			'module.exports = "Text <script src=\\"" + require("./script.js") + "\\"><img src=\\"" + require("./image.png") + "\\">";'
 		);
 	});
+	it("should accept :attribute (empty tag) from query", function() {
+		loader.call({
+			query: "?attrs[]=:custom-src"
+		}, 'Text <custom-element custom-src="image1.png"><custom-img custom-src="image2.png"/></custom-element>').should.be.eql(
+			'module.exports = "Text <custom-element custom-src=\\"" + require("./image1.png") + "\\"><custom-img custom-src=\\"" + require("./image2.png") + "\\"/></custom-element>";'
+		);
+	});
 	it("should not make bad things with templates", function() {
 		loader.call({}, '<h3>#{number} {customer}</h3>\n<p>   {title}   </p>').should.be.eql(
 			'module.exports = "<h3>#{number} {customer}</h3>\\n<p>   {title}   </p>";'


### PR DESCRIPTION
Hi!

I'd like to propose a little change that would make possible to match every element that use a specific attribute, without bloating the config file... I work in a project that use `<custom-tags>` so currently each time we add a new element that want to load an image, we are forced to update the config file... this change would avoid that.

Tests are passing and it's not a breaking change, AFAIK.

Any feedback is welcomed.

Many thanks! ❤️ 
