### PR TITLE
feat: add parsing support for inline styles with url() functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ npm i -D html-loader
 
 By default every local `<img src="image.png">` is required (`require('./image.png')`). You may need to specify loaders for images in your configuration (recommended `file-loader` or `url-loader`).
 
-You can specify which tag-attribute combination should be processed by this loader via the query parameter `attrs`. Pass an array or a space-separated list of `<tag>:<attribute>` combinations. (Default: `attrs=img:src`)
+You can specify which tag-attribute combination should be processed by this loader via the query parameter `attrs`. Pass an array or a space-separated list of `<tag>:<attribute>` combinations. (Default: `attrs=img:src :style`)
 
 If you use `<custom-elements>`, and lots of them make use of a `custom-src` attribute, you don't have to specify each combination `<tag>:<attribute>`: just specify an empty tag like `attrs=:custom-src` and it will match every element.
 

--- a/index.js
+++ b/index.js
@@ -26,7 +26,7 @@ function getLoaderConfig(context) {
 module.exports = function(content) {
 	this.cacheable && this.cacheable();
 	var config = getLoaderConfig(this);
-	var attributes = ["img:src"];
+	var attributes = ["img:src", ":style"];
 	if(config.attrs !== undefined) {
 		if(typeof config.attrs === "string")
 			attributes = config.attrs.split(" ");

--- a/lib/attributesParser.js
+++ b/lib/attributesParser.js
@@ -27,9 +27,25 @@ var parser = new Parser({
 	inside: {
 		"\\s+": true, // eat up whitespace
 		">": "outside", // end of attributes
+		"style\\s*=\\s*\"": 'styleAttr',
+		"style\\s*=\\s*\'": 'styleAttrSingleQuote',
 		"(([0-9a-zA-Z\\-:]+)\\s*=\\s*\")([^\"]*)\"": processMatch,
 		"(([0-9a-zA-Z\\-:]+)\\s*=\\s*\')([^\']*)\'": processMatch,
 		"(([0-9a-zA-Z\\-:]+)\\s*=\\s*)([^\\s>]+)": processMatch
+	},
+	styleAttr: {
+		"\\s+": true, // eat up whitespace
+		"\"": "inside", // end of style attribute
+		"((url\\(\'))([^\\)]*)\'\\)": function(match, strUntilValue, name, value, index) {
+			return processMatch.call(this, match, strUntilValue, 'style', value, index)
+		}
+	},
+	styleAttrSingleQuote: {
+		"\\s+": true, // eat up whitespace
+		"\'": "inside", // end of style attribute
+		"((url\\(\"))([^\\)]*)\"\\)": function(match, strUntilValue, name, value, index) {
+			return processMatch.call(this, match, strUntilValue, 'style', value, index)
+		}
 	}
 });
 

--- a/lib/attributesParser.js
+++ b/lib/attributesParser.js
@@ -27,24 +27,24 @@ var parser = new Parser({
 	inside: {
 		"\\s+": true, // eat up whitespace
 		">": "outside", // end of attributes
-		"style\\s*=\\s*\"": 'styleAttr',
-		"style\\s*=\\s*\'": 'styleAttrSingleQuote',
+		"style\\s*=\\s*([\"\'])": function(match, quoteType) {
+			this.styleQuoteType = quoteType;
+			return "styleAttr";
+		},
 		"(([0-9a-zA-Z\\-:]+)\\s*=\\s*\")([^\"]*)\"": processMatch,
 		"(([0-9a-zA-Z\\-:]+)\\s*=\\s*\')([^\']*)\'": processMatch,
 		"(([0-9a-zA-Z\\-:]+)\\s*=\\s*)([^\\s>]+)": processMatch
 	},
 	styleAttr: {
 		"\\s+": true, // eat up whitespace
-		"\"": "inside", // end of style attribute
-		"((url\\(\'))([^\\)]*)\'\\)": function(match, strUntilValue, name, value, index) {
-			return processMatch.call(this, match, strUntilValue, 'style', value, index)
-		}
-	},
-	styleAttrSingleQuote: {
-		"\\s+": true, // eat up whitespace
-		"\'": "inside", // end of style attribute
-		"((url\\(\"))([^\\)]*)\"\\)": function(match, strUntilValue, name, value, index) {
-			return processMatch.call(this, match, strUntilValue, 'style', value, index)
+		"\\\\[\'\"]": true, // eat escaped quotes so the end of style attribute rule doesn't find them
+		"([\"\'])": function(match, quoteType) {
+			return this.styleQuoteType === quoteType ?
+				"inside" : // end of style attribute, beginning and end quotes match
+				false;
+		},
+		"((url\\([\"\']?))([^\"\'\\)]*)[\"\']?\\)": function(match, strUntilValue, name, value, index) {
+			return processMatch.call(this, match, strUntilValue, "style", value, index)
 		}
 	}
 });
@@ -52,6 +52,7 @@ var parser = new Parser({
 module.exports = function parse(html, isRelevantTagAttr) {
 	return parser.parse("outside", html, {
 		currentTag: null,
+		styleQuoteType: null,
 		results: [],
 		isRelevantTagAttr: isRelevantTagAttr
 	}).results;

--- a/test/parserTest.js
+++ b/test/parserTest.js
@@ -9,6 +9,7 @@ function test(name, html, result) {
 			if(tag === "link" && attr === "href") return true;
 			if(tag === "div" && attr === "data-videomp4") return true;
 			if(tag === "use" && attr === "xlink:href") return true;
+			if(tag === "div" && attr === "style") return true;
 			return false;
 		}).map(function(match) {
 			return match.value
@@ -34,6 +35,10 @@ describe("parser", function() {
 	test("doctype", '<!doctype html><img src="image.png">', ["image.png"]);
 	test("alphanumeric", '<div data-videomp4="video.mp4"></div>', ["video.mp4"]);
 	test("use", '<use xlink:href="vector.svg" />', ["vector.svg"]);
+	test("use", '<use xlink:href="vector.svg" />', ["vector.svg"]);
+	test("inline style url", '<div style="background-image: url(\'image.png\')"></div>', ["image.png"]);
+	test("inline style url w/ flipped quotes", '<div style=\'background-image: url("image.png")\'></div>', ["image.png"]);
+	test("multiple inline style urls", '<div style="background-image: url(\'image.png\'); list-style: square url(\'image2.png\')"></div>', ["image.png", "image2.png"]);
 });
 
 describe("locations", function() {

--- a/test/parserTest.js
+++ b/test/parserTest.js
@@ -37,8 +37,12 @@ describe("parser", function() {
 	test("use", '<use xlink:href="vector.svg" />', ["vector.svg"]);
 	test("use", '<use xlink:href="vector.svg" />', ["vector.svg"]);
 	test("inline style url", '<div style="background-image: url(\'image.png\')"></div>', ["image.png"]);
-	test("inline style url w/ flipped quotes", '<div style=\'background-image: url("image.png")\'></div>', ["image.png"]);
-	test("multiple inline style urls", '<div style="background-image: url(\'image.png\'); list-style: square url(\'image2.png\')"></div>', ["image.png", "image2.png"]);
+	test("inline style url w/ outer single quotes", '<div style=\'background-image: url("image.png")\'></div>', ["image.png"]);
+	test("inline style url w/ no quotes", '<div style="background-image: url(image.png)"></div>', ["image.png"]);
+	test("inline style url w/ outer single quotes and no inner quotes", '<div style=\'background-image: url(image.png)\'></div>', ["image.png"]);
+	test("inline style url w/ other quotes", '<div style="font-family: \'test\', serif; background-image: url(image.png);"></div>', ["image.png"]);
+	test("inline style url w/ escaped other quotes", '<div style="font-family: \\"test\\", serif; background-image: url(image.png);"></div>', ["image.png"]);
+	test("inline style multiple urls", '<div style="background-image: url(\'image.png\'); list-style: square url(\'image2.png\')"></div>', ["image.png", "image2.png"]);
 });
 
 describe("locations", function() {


### PR DESCRIPTION
- Include all `style` attributes by default

**Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
By default it ignores `style` attributes. If you specify to include `style` attributes, it doesn't look inside them and would treat the entire attribute value as a single url.
 
Addresses https://github.com/webpack-contrib/html-loader/issues/131


**What is the new behavior?**
If the parser encounters a `style` attribute, it searches the value for `url(..)` functions and returns the urls as links instead of looking at it as a whole.


**Does this PR introduce a breaking change?**
- [x] Yes
- [ ] No

If this PR contains a breaking change, please describe the following... 

* Impact:
  - The current state of this PR changes the `attrs` config default to include `:style`. I could change that back and make this feature opt-in which would reduce the impact.
  - Could affect people who were using an [`interpolate` solution](https://github.com/webpack-contrib/html-loader/issues/131#issuecomment-328223407) to get around this. I think this new feature would fail to resolve a `url()` with `require` inside but I'm not certain and then the interpolate would continue to work after.
  - Could surprise people who were relying on this not working and had their app working without url resolving.
  - Hopefully no one is putting a single url in a `style` attr like `style="./image.png"` so, if this is not default, it may not be a breaking change.
* Migration path for existing applications:  Change defaults or update `url()`s
* Github Issue(s) this is regarding: https://github.com/webpack-contrib/html-loader/issues/131


**Other information**:
***Possible improvements***:
- Figure out a way to short circuit the `styleAttr` states if `:style` is not in the `attrs` config. This could improve performance as we don't have to look through potentially large inline styles. I'm not sure if it would gracefully get past the end of the style tag if we just returned on a match without transitioning to the `styleAttr` state.
- ~~Combine my `styleAttr` and `styleAttrSingleQuote` states. I'm not sure that it's possible to change the lefthand regexes on the fly. I suppose we could make a function that would generate these 2 variants~~ Added a commit to improve this.
- Find a cleaner way to change the attr name when calling `processMatch` match than `processMatch.call`. It feels verbose the way I have it.
- Add an example to the Readme. Would require a new example file with an inline style url. Currently the [Examples](https://github.com/webpack-contrib/html-loader#examples) section doesn't seem organized very well and is a wall of code snippets. It would probably need some cleanup if we throw another input html file into the mix.

Thanks for considering this. Feel free to suggest changes :) Let me know if you see any other cases that need to be handled or any potential errors in the regexes.