### PR TITLE
fix: ignore attribute if `mailto:` is present

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,6 +53,8 @@ module.exports = function(content) {
 	content = [content];
 	links.forEach(function(link) {
 		if(!loaderUtils.isUrlRequest(link.value, root)) return;
+		
+		if (link.value.indexOf('mailto:') > -1 ) return;
 
 		var uri = url.parse(link.value);
 		if (uri.hash !== null && uri.hash !== undefined) {

--- a/test/loaderTest.js
+++ b/test/loaderTest.js
@@ -150,6 +150,11 @@ describe("loader", function() {
 			'module.exports = "<img src=\\"" + require("./icons.svg") + "#hash\\">";'
 		);
 	});
+	it("should ignore anchor with 'mailto:' in the href attribute", function() {
+		loader.call({}, '<a href="mailto:username@exampledomain.com"></a>').should.be.eql(
+			'module.exports = "<a href=\\"mailto:username@exampledomain.com\\"></a>";'
+		);
+	});
 	it("should ignore interpolations by default", function() {
 		loader.call({}, '<img src="${"Hello " + (1+1)}">').should.be.eql(
 			'module.exports = "<img src=\\"${\\"Hello \\" + (1+1)}\\">";'


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
If I have a 'mailto' inside a href in an anchor tag file-loader tries to load a non existent file called "mailto:examplemail@exampledomain.com"

**What is the new behavior?**
Ignore href in anchor tag if the string 'mailto:' is present


**Does this PR introduce a breaking change?**
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the following... 

* Impact:
* Migration path for existing applications: 
* Github Issue(s) this is regarding:


**Other information**: