### PR TITLE
feat: add `ignoreFiles` option (`options.ignoreFiles`)

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,29 @@ require("html-loader?root=.!./file.html");
 // => '<img  src="http://cdn.example.com/49eba9f/a992ca.jpg">'
 ```
 
+### Ignore specified image files
+
+You can use `ignoreFiles` option to ignore some image files, like so:
+
+```js
+module: {
+  rules: [{
+    test: /\.html$/,
+    use: [ {
+      loader: 'html-loader',
+      options: {
+        ignoreFiles: [
+            /{{.*?}}/
+        ]
+      }
+    }],
+  }]
+}
+```
+
+`<img src="angular{{version}}.jpg"/>` should be remained as `<img src="angular{{version}}.jpg"/>`.
+You can also use a function or a string instead of the RegExp.
+
 ### Interpolation
 
 You can use `interpolate` flag to enable interpolation syntax for ES6 template strings, like so:

--- a/test/loaderTest.js
+++ b/test/loaderTest.js
@@ -174,6 +174,67 @@ describe("loader", function() {
 			'module.exports = "<a href=\\"${list.href}\\"><img src=\\"" + require("./test.jpg") + "\\" /></a>";'
 		);
 	});
+	it("should ignore files specified by regexp", function() {
+		loader.call({
+			options: {
+				htmlLoader: {
+					ignoreFiles: [/{{.*?}}/]
+				}
+			}
+		}, '<img src="angular{{version}}.jpg"/>').should.be.eql('module.exports = "<img src=\\"angular{{version}}.jpg\\"/>";');
+	});
+
+	it("should ignore files specified by regexp(string)", function() {
+		loader.call({
+			options: {
+				htmlLoader: {
+					ignoreFiles: ["{{.*?}}"]
+				}
+			}
+		}, '<img src="angular{{version}}.jpg"/>').should.be.eql('module.exports = "<img src=\\"angular{{version}}.jpg\\"/>";');
+	});
+
+	it("should ignore files specified by function", function() {
+		loader.call({
+			options: {
+				htmlLoader: {
+					ignoreFiles: [function(fileName) {
+						return /{{.*?}}/.test(fileName);
+					}]
+				}
+			}
+		}, '<img src="angular{{version}}.jpg"/>').should.be.eql('module.exports = "<img src=\\"angular{{version}}.jpg\\"/>";');
+	});
+
+	it("should ignore files specified by multiple filters", function() {
+		loader.call({
+			options: {
+				htmlLoader: {
+					ignoreFiles: [
+						function(fileName) {
+							return /{{.*?}}/.test(fileName);
+						},
+						/no-hash/,
+					]
+				}
+			}
+		}, '<img src="angular{{version}}.jpg"/><img src="no-hash.png"/>').should.be.eql('module.exports = "<img src=\\"angular{{version}}.jpg\\"/><img src=\\"no-hash.png\\"/>";');
+	});
+
+	it("should throw an error for illegal `ignoreFiles`", function() {
+		should(function illegalOption() {
+			loader.call({
+				options: {
+					htmlLoader: {
+						ignoreFiles: [
+							1
+						]
+					}
+				}
+			}, '<img src="angular{{version}}.jpg"/><img src="no-hash.png"/>');
+		}).throw();
+	});
+
 	it("should export as default export for es6to5 transpilation", function() {
 		loader.call({
 			query: "?exportAsDefault"


### PR DESCRIPTION
It is useful for handling Angular templates correctly. see https://github.com/angular/angular-cli/issues/3415

**Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

`<img src="angular{{version}}.jpg"/>` cause an error.

**What is the new behavior?**

`<img src="angular{{version}}.jpg"/>` will keep as it is.

**Does this PR introduce a breaking change?**
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the following... 

* Impact:
* Migration path for existing applications: 
* Github Issue(s) this is regarding:


**Other information**:

My English writing is so bad, please edit my English statement freely.