### PR TITLE
fix(index): escape double quotes correctly (`options.interpolate`)

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,7 +53,7 @@ module.exports = function(content) {
 	content = [content];
 	links.forEach(function(link) {
 		if(!loaderUtils.isUrlRequest(link.value, root)) return;
-		
+
 		if (link.value.indexOf('mailto:') > -1 ) return;
 
 		var uri = url.parse(link.value);
@@ -129,6 +129,9 @@ module.exports = function(content) {
 	}
 
 	if(config.interpolate && config.interpolate !== 'require') {
+		// Double escape quotes so that they are not unescaped completely in the template string
+		content = content.replace(/\\"/g, "\\\\\"");
+		content = content.replace(/\\'/g, "\\\\\'");
 		content = compile('`' + content + '`').code;
 	} else {
 		content = JSON.stringify(content);

--- a/test/loaderTest.js
+++ b/test/loaderTest.js
@@ -71,6 +71,11 @@ describe("loader", function() {
 			'module.exports = "<!-- comment --><h3 customattr=\\"\\">#{number} {customer}</h3><p>{title}</p><!-- comment --><img src=\" + require("./image.png") + \" />";'
 		);
 	});
+	it("should preserve escaped quotes", function() {
+		loader.call({}, '<script>{"json": "with \\"quotes\\" in value"}</script>').should.be.eql(
+			'module.exports = "<script>{\\\"json\\\": \\\"with \\\\\\\"quotes\\\\\\\" in value\\\"}</script>";'
+		);
+	})
 
 	it("should preserve comments and white spaces when minimizing (via webpack config property)", function() {
 		loader.call({
@@ -167,6 +172,13 @@ describe("loader", function() {
 			'module.exports = "<img src=\\"" + ("Hello " + (1 + 1)) + "\\">";'
 		);
 	});
+	it("should not change handling of quotes when interpolation is enabled", function() {
+		loader.call({
+			query: "?interpolate"
+		}, '<script>{"json": "with \\"quotes\\" in value"}</script>').should.be.eql(
+			'module.exports = "<script>{\\\"json\\\": \\\"with \\\\\\\"quotes\\\\\\\" in value\\\"}</script>";'
+		);
+	})
 	it("should enable interpolations when using interpolate=require flag and only require function to be translate", function() {
 		loader.call({
 			query: "?interpolate=require"


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
Currently escaped quotes in inline scripts are unescaped when interpolation is enabled. You can find a minimal test case here: https://github.com/benurb/html-loader-escape-bug


**What is the new behavior?**
interpolate=true behaves like disabled interpolation and quotes are still escaped.


**Does this PR introduce a breaking change?**
- [ ] Yes
- [x] No
The documentation states no difference between interpolate=true and false regarding the handling of escaped quotes.

If this PR contains a breaking change, please describe the following... 

**Other information**:
This solution is very hacky, but I couldn't find a cleaner one 😞 
Without these changes the second of the two added tests fails.
This PR might also be a fix for #153 though I don't use angular and haven't tested it.