### PR TITLE
fix(index): don't prepend `./` to the URL on `interpolate=require` (`options.interpolate`)

### DIFF
--- a/index.js
+++ b/index.js
@@ -156,7 +156,7 @@ module.exports = function(content) {
 			urlToRequest = loaderUtils.urlToRequest(data[match], root);
 		}
 		
-		return '" + require(' + JSON.stringify(loaderUtils.urlToRequest(data[match], root)) + ') + "';
+		return '" + require(' + JSON.stringify(urlToRequest) + ') + "';
 	}) + ";";
 
 }

--- a/index.js
+++ b/index.js
@@ -147,6 +147,15 @@ module.exports = function(content) {
 
  	return exportsString + content.replace(/xxxHTMLLINKxxx[0-9\.]+xxx/g, function(match) {
 		if(!data[match]) return match;
+		
+		var urlToRequest;
+
+		if (config.interpolate === 'require') {
+			urlToRequest = data[match];
+		} else {
+			urlToRequest = loaderUtils.urlToRequest(data[match], root);
+		}
+		
 		return '" + require(' + JSON.stringify(loaderUtils.urlToRequest(data[match], root)) + ') + "';
 	}) + ";";
 


### PR DESCRIPTION
This fixes bug #150 where the URL passed to `require()` would have `./` prepended when it shouldn't.

**Please check if the PR fulfills these requirements**
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
https://github.com/webpack-contrib/html-loader/issues/150


**What is the new behavior?**
`require`, when interpolated, will no longer prepend `./` to the request url.


**Does this PR introduce a breaking change?**
- [ ] Yes
- [X] No

If this PR contains a breaking change, please describe the following... 

* Impact:
* Migration path for existing applications: 
* Github Issue(s) this is regarding:


**Other information**: