### PR TITLE
docs(readme): migrate from deprecated `!` loader syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,7 +275,7 @@ will write the _.html_ file for you. Example:
 ```js
 {
   test: /\.html$/,
-  use: [ 'file-loader?name=[path][name].[ext]!extract-loader!html-loader' ]
+  use: ['file-loader?name=[name].[ext]', 'extract-loader', 'html-loader'],
 }
 ```
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Other... Please describe: updated `README.md`

**What is the current behavior?** (You can also link to an open issue here)
According to https://github.com/webpack/webpack/issues/3713#issuecomment-270365920 `use: [ 'file-loader?name=[path][name].[ext]!extract-loader!html-loader' ]` is not expected to work (and it didn't work for me using wepack 4 and latest version of `html-loader`).

**What is the new behavior?**



**Does this PR introduce a breaking change?**
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the following... 

* Impact:
* Migration path for existing applications: 
* Github Issue(s) this is regarding:


**Other information**: