### PR TITLE
fix(attributesParser): allow digits in element names

### DIFF
--- a/lib/attributesParser.js
+++ b/lib/attributesParser.js
@@ -19,7 +19,7 @@ var parser = new Parser({
 		"<![CDATA[.*?]]>": true,
 		"<[!\\?].*?>": true,
 		"<\/[^>]+>": true,
-		"<([a-zA-Z\\-:]+)\\s*": function(match, tagName) {
+		"<([0-9a-zA-Z\\-:]+)\\s*": function(match, tagName) {
 			this.currentTag = tagName;
 			return "inside";
 		}

--- a/test/loaderTest.js
+++ b/test/loaderTest.js
@@ -15,6 +15,13 @@ describe("loader", function() {
 			'module.exports = "Text <script src=\\"" + require("./script.js") + "\\"><img src=\\"image.png\\">";'
 		);
 	});
+	it("should accept attrs for elements with number", function() {
+		loader.call({
+			query: "?attrs=ga2-img:src"
+		}, 'Text <ga2-img src="image.png"></ga2-img>').should.be.eql(
+			'module.exports = "Text <ga2-img src=\\"" + require("./image.png") + "\\"></ga2-img>";'
+		);
+	});
 	it("should accept attrs from query (space separated)", function() {
 		loader.call({
 			query: "?attrs=script:src img:src"


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- [X] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

Given this configuration :
```json
{
  "attrs": ["img:src", "sglk2-svg:src"]
}
```
The attribute in this HTML is not replaced by the require() call :
```html
<sglk2-svg src="icons/info.svg"></sglk2-svg>
```

Because the attributes parser does not allow digits in tag names (though it's perfectly valid).


**What is the new behavior?**

Digits are allowed in tag names.

**Does this PR introduce a breaking change?**
- [ ] Yes
- [X] No
