### PR TITLE
Fix: backticks in templates cause errors if `interpolate` flag is set

### DIFF
--- a/index.js
+++ b/index.js
@@ -132,6 +132,7 @@ module.exports = function(content) {
 		// Double escape quotes so that they are not unescaped completely in the template string
 		content = content.replace(/\\"/g, "\\\\\"");
 		content = content.replace(/\\'/g, "\\\\\'");
+		content = content.replace(/`/g, "\\`");
 		content = compile('`' + content + '`').code;
 	} else {
 		content = JSON.stringify(content);
@@ -147,7 +148,7 @@ module.exports = function(content) {
 
  	return exportsString + content.replace(/xxxHTMLLINKxxx[0-9\.]+xxx/g, function(match) {
 		if(!data[match]) return match;
-		
+
 		var urlToRequest;
 
 		if (config.interpolate === 'require') {
@@ -155,7 +156,7 @@ module.exports = function(content) {
 		} else {
 			urlToRequest = loaderUtils.urlToRequest(data[match], root);
 		}
-		
+
 		return '" + require(' + JSON.stringify(urlToRequest) + ') + "';
 	}) + ";";
 

--- a/test/loaderTest.js
+++ b/test/loaderTest.js
@@ -179,6 +179,13 @@ describe("loader", function() {
 			'module.exports = "<script>{\\\"json\\\": \\\"with \\\\\\\"quotes\\\\\\\" in value\\\"}</script>";'
 		);
 	})
+	it("should allow to interpolate templates that contain backticks", function() {
+		loader.call({
+			query: "?interpolate"
+		}, '<p>Something about the ` character</p>').should.be.eql(
+			'module.exports = "<p>Something about the ` character</p>";'
+		);
+	})
 	it("should enable interpolations when using interpolate=require flag and only require function to be translate", function() {
 		loader.call({
 			query: "?interpolate=require"


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
Backticks in templates cause an exception if the `interpolate` flag is set.

**What is the new behavior?**
It works :-)


**Does this PR introduce a breaking change?**
- [ ] Yes
- [x] No
