### PR TITLE
Add `processOther` option for dealing with non-webpack module requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ require("html-loader?attrs=img:data-src!./file.html");
 require("html-loader?attrs=img:src img:data-src!./file.html");
 require("html-loader?attrs[]=img:src&attrs[]=img:data-src!./file.html");
 
-// => '<img  src="http://cdn.example.com/49eba9f/a992ca.png"        
+// => '<img  src="http://cdn.example.com/49eba9f/a992ca.png"
 //           data-src="data:image/png;base64,..." >'
 ```
 
@@ -253,6 +253,41 @@ module.exports = {
   },
   otherHtmlLoaderConfig: {
     ...
+  }
+};
+```
+
+### Processing non-webpack Resources
+
+The html-loader doesn't process resources that are external or `mailto:` or other unable to be handled by webapck. However, you can do what you like with these by adding a `processOther` function to the loader's options. For example, say you want to be warned about any external URLs that don't exist, you could use the following:
+
+```js
+var rp = require('request-promise')
+
+module.exports = {
+  ...
+  module: {
+    rules: [
+      {
+        test: /\.html$/,
+        use: {
+          loader: "html-loader",
+          options: {
+            processOther: function(url) {
+              if (url.indexOf('mailto:') < 0) {
+                rp.head(url).catch(function() {
+                  console.warn("Using a URL in html that doesn't exist: " + url))
+                })
+              }
+            },
+          }
+      }
+    ]
+  },
+  htmlLoader: {
+    ignoreCustomFragments: [/\{\{.*?}}/],
+    root: path.resolve(__dirname, 'assets'),
+    attrs: ['img:src', 'link:href']
   }
 };
 ```

--- a/index.js
+++ b/index.js
@@ -52,9 +52,7 @@ module.exports = function(content) {
 	var data = {};
 	content = [content];
 	function processOther(link) {
-		try {
-			config.processOther && config.processOther(link.value);
-		} catch(e) {}
+		config.processOther && config.processOther(link.value);
 	}
 	links.forEach(function(link) {
 		if(!loaderUtils.isUrlRequest(link.value, root)) return processOther(link);

--- a/index.js
+++ b/index.js
@@ -51,10 +51,15 @@ module.exports = function(content) {
 	links.reverse();
 	var data = {};
 	content = [content];
+	function processOther(link) {
+		try {
+			config.processOther && config.processOther(link.value);
+		} catch(e) {}
+	}
 	links.forEach(function(link) {
-		if(!loaderUtils.isUrlRequest(link.value, root)) return;
+		if(!loaderUtils.isUrlRequest(link.value, root)) return processOther(link);
 
-		if (link.value.indexOf('mailto:') > -1 ) return;
+		if (link.value.indexOf('mailto:') > -1 ) return processOther(link);
 
 		var uri = url.parse(link.value);
 		if (uri.hash !== null && uri.hash !== undefined) {
@@ -147,7 +152,7 @@ module.exports = function(content) {
 
  	return exportsString + content.replace(/xxxHTMLLINKxxx[0-9\.]+xxx/g, function(match) {
 		if(!data[match]) return match;
-		
+
 		var urlToRequest;
 
 		if (config.interpolate === 'require') {
@@ -155,7 +160,7 @@ module.exports = function(content) {
 		} else {
 			urlToRequest = loaderUtils.urlToRequest(data[match], root);
 		}
-		
+
 		return '" + require(' + JSON.stringify(urlToRequest) + ') + "';
 	}) + ";";
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
Currently, any resource URI that isn't able to be processed by webpack as a module request is simply ignored, silently.

**What is the new behavior?**
This new behavior simply adds a `processOther` callback that is called with each resource URI that isn't processed by webpack. This includes all external URLs like `https://some-cdn.com/something` as well as mailto links like `mailto:me@somewhere.com`, as well as URLs that are otherwise invalid and unable to be treated as webpack module requests. Importantly, this provides a place for developers to for instance throw an error if some external resource is invalid in some expected way. Without this feature, developers such as myself would have to duplicate a large portion of the `html-loader`'s functionality to achieve the same capability.

**Does this PR introduce a breaking change?**
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the following... 

* Impact:
* Migration path for existing applications: 
* Github Issue(s) this is regarding:


**Other information**:
Thank you for this practically universally useful loader!! ❤️