### PR TITLE
Add prehtml-loader to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,51 @@ will write the _.html_ file for you. Example:
   use: ['file-loader?name=[name].[ext]', 'extract-loader', 'html-loader'],
 }
 ```
+### Passing parameters to html-loader
+
+The loader `prehtml-loader` enables to pass parameters to `html-loader`, as well as building HTML templates:
+```html
+<!-- foo.html -->
+${scope.w1} ${scope.w2}!
+```
+```js
+import './foo.html?w1=Hello&w2=World'
+// => Hello World!
+```
+
+```js
+<!-- webpack.config.js -->
+var path = require('path');
+
+module.exports = {
+
+	module: {
+		rules: [{
+			issuer: {test: /\.js$/},
+			enforce: 'post',
+			test: /\.html$/,
+			use: ['file-loader?name=[name].[ext]', 'extract-loader', 'html-loader?interpolate']
+		}, {
+			issuer: {exclude: /\.js$/},
+			enforce: 'post',
+			test: /\.html$/,
+			use: ['html-loader?interpolate']
+		}, {
+		    test: /\.html$/,
+		    use: 'prehtml-loader'
+		},
+	]},
+	entry: './foo.js',
+	output: {
+		path: path.resolve(__dirname, 'dist'),
+		filename: 'foo.bundle.js'
+	}
+};
+```
+
+See `prehtml-loader` documentation for more features and details:
+https://github.com/denis-migdal/prehtml-loader
+
 
 <h2 align="center">Maintainers</h2>
 


### PR DESCRIPTION
See https://github.com/webpack-contrib/html-loader/issues/206

<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [ ] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**
- [X] Documentation modification

### Motivation / Use-Case

Cite new loader `prehtml-loader` in the documentation.

See https://github.com/webpack-contrib/html-loader/issues/206

### Breaking Changes

No breaking changes.

### Additional Info

See https://github.com/webpack-contrib/html-loader/issues/206