### PR TITLE
Optimize the img tag SRC attribute is empty

### DIFF
--- a/index.js
+++ b/index.js
@@ -146,7 +146,7 @@ module.exports = function(content) {
 	}
 
  	return exportsString + content.replace(/xxxHTMLLINKxxx[0-9\.]+xxx/g, function(match) {
-		if(!data[match]) return match;
+		if(!data[match]) return '';
 		
 		var urlToRequest;
 

--- a/test/loaderTest.js
+++ b/test/loaderTest.js
@@ -8,6 +8,11 @@ describe("loader", function() {
 			'module.exports = "Text <img src=\\"" + require("./image.png") + "\\"><img src=\\"" + require("bootstrap-img") + "\\"> Text";'
 		);
 	});
+	it("should remain unchanged when img tag src attribute is empty", function() {
+		loader.call({}, 'Text <img src=""> Text').should.be.eql(
+			'module.exports = "Text <img src=\\"\\"> Text";'
+		);
+	});
 	it("should accept attrs from query", function() {
 		loader.call({
 			query: "?attrs=script:src"


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [x] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

<!--
  Please explain the motivation or use-case for your change.
  What existing problem does the PR solve?
  If this PR addresses an issue, please link to the issue.
-->
when html file have
```html
<img src="" />
```
tag, We should return 
```html
 <img src="" />
```
instead of 
```html
<img src="xxxHTMLLINKxxx0.241767597227476870.4882104576985471xxx" />
```

### Breaking Changes

<!--
  If this PR introduces a breaking change, please describe the impact and a
  migration path for existing applications.
-->

### Additional Info
