### PR TITLE
docs(readme): restore extract-loader usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1055,7 +1055,7 @@ module.exports = {
       },
       {
         test: /\.html$/i,
-        use: ["html-loader"],
+        use: ["extract-loader", "html-loader"],
       },
     ],
   },


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [ ] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [x] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

<!--
  Please explain the motivation or use-case for your change.
  What existing problem does the PR solve?
  If this PR addresses an issue, please link to the issue.
-->
The docs mention the use of `extract-loader`, but the example which mentions it does not actually use it. This appears to be an unintentional change made as part of #423, as that pull request does not mention any intent to change the docs.

### Additional Info
I tested the example configuration using webpack 5, html-loader v4.1.0, and extract-loader v5.1.0.